### PR TITLE
10th November 2017 PJS updates

### DIFF
--- a/default.htm
+++ b/default.htm
@@ -64,10 +64,9 @@
 		<div id="zone2panel">
 		  <div class="container first">
 			<h6>Latest News</h6>
-			<p><strong>New Products</strong>
+			<p><strong>PolypVac in the News</strong>
             
-           <p>The PolypVac Microdebrider is a unique new device to remove nasal polyps under local anaesthesia. </p>
-            <p>For more information click <a href="polypvac.htm">here</a>.</p>
+           <p>A feature on the new <a href="polypvac.htm">PolypVac</a> microdebrider appeared in a recent edition of the Daily Mail.  To see the article, <a href=" http://www.dailymail.co.uk/health/article-5055781/A-vacuum-cleaner-nose-banished-snoring.html" target="_blank">click here</a>.</p>
 		  </div>
 		  <div class="container">
 		  </div>

--- a/polypvac.htm
+++ b/polypvac.htm
@@ -56,6 +56,7 @@
 		<div class="editorial">
 		  <p>Manufactured by Laurimed of Redwood City, California, USA, PolypVac is a single-use device designed to remove nasal polyps under local anaesthesia, using airflow from a suction source, either wall-mounted or pump. Its malleable tip and unique reciprocating action give a clean shearing cut, with no need to change blades.</p>
 		  <p>For further information, including case studies, click <a href="http://www.polypvac.com/physician" target="_blank">here</a>.</p>
+          <p>For information on where treatment with the PolypVac is currently available in the UK, see <a href="http://www.manchesterentspecialist.co.uk" target="_blank">www.manchesterentspecialist.co.uk</a>.</p>
 		</div>
 	  </div><div class="zone2">
 		<img src="images/right/default.jpg" alt="" />


### PR DESCRIPTION
On the Home Page, under “Latest News”, change the entry to:

*PolypVac in the News

A feature on the new PolypVac microdebrider appeared in a recent
edition of the Daily Mail.  To see the article, click here (link to
http://www.dailymail.co.uk/health/article-5055781/A-vacuum-cleaner-nose-
banished-snoring.html”

On the PolypVac page add

“For information on where treatment with the PolypVac is currently
available in the UK, see the following links:

www.manchesterentspecialist.co.uk”